### PR TITLE
El9 matplotlib plotting

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ cd CombineHarvester/
 cd ..
 scramv1 b clean
 scramv1 b -j 16
-git clone --branch el9_debug git@github.com:JHU-Tools/2DAlphabet.git
+git clone --branch el9_matplotlib_plotting git@github.com:JHU-Tools/2DAlphabet.git
 python3 -m virtualenv twoD-env
 source twoD-env/bin/activate
 cd 2DAlphabet/

--- a/TwoDAlphabet/condor/jdl_template_lorien
+++ b/TwoDAlphabet/condor/jdl_template_lorien
@@ -1,0 +1,8 @@
+universe	= vanilla
+executable 	= TEMPSCRIPT
+RequestMemory = 1000
+Output 		= notneeded/output_$(Cluster)_$(Process).stdout
+Error 		= notneeded/output_$(Cluster)_$(Process).stderr
+Log 		= notneeded/output_$(Cluster)_$(Process).log
+Arguments 	= "$(args)"
+Queue args from TEMPARGS

--- a/TwoDAlphabet/config.py
+++ b/TwoDAlphabet/config.py
@@ -3,6 +3,7 @@ import ROOT, json, os, pandas, re, warnings, itertools
 from numpy import nan
 import pprint
 pp = pprint.PrettyPrinter(indent=4)
+from TwoDAlphabet.plotstyle import mpl_to_root_colors, root_to_matplotlib_color
 from TwoDAlphabet.helpers import copy_update_dict, open_json, parse_arg_dict, replace_multi
 from TwoDAlphabet.binning import Binning, copy_hist_with_new_bins, get_bins_from_hist
 
@@ -411,7 +412,11 @@ class OrganizedHists():
                     h.SetName(row.out_histname)
 
                 h.SetTitle(row.out_histname)
-                h.SetFillColor(row.color)
+                if row.color not in mpl_to_root_colors.keys():
+                    available_colors = '", "'.join(mpl_to_root_colors.keys())
+                    raise ValueError(f'Color "{color}" not defined. Please add the ROOT TColor code to the "mpl_to_root_colors" dictionary defined in TwoDAlphabet.plotstyle. Available default colors are: "{available_colors}"')
+                else:
+                    h.SetFillColor(mpl_to_root_colors[row.color])
 
                 self.file.WriteTObject(h, row.out_histname)
                 self.CreateSubRegions(h, binning)

--- a/TwoDAlphabet/config.py
+++ b/TwoDAlphabet/config.py
@@ -100,10 +100,13 @@ class Config:
         json.dump(self.config,file_out,indent=2,sort_keys=True)
         file_out.close()
 
-    def FullTable(self):
+    def FullTable(self,verbose=False):
         '''Generate full table of processes, regions, and systematic variations
         to account for, including relevant information for each. The table is
         returned as a pandas DataFrame for convenient manipulation.
+
+        Args:
+            verbose (bool): If True, prints the regions, processes, and systematics dataframe tables to .txt files.
 
         Returns:
             pandas.DataFrame: Table
@@ -112,9 +115,10 @@ class Config:
         processes = self._processTable()
         systematics = self._systematicsTable()
 
-        regions.to_string('regions.txt')
-        processes.to_string('processes.txt')
-        systematics.to_string('systematics.txt')
+        if verbose:
+            regions.to_string('regions.txt')
+            processes.to_string('processes.txt')
+            systematics.to_string('systematics.txt')
 
         for p,group in processes.groupby(processes.index):
             if group.title.nunique() > 1:

--- a/TwoDAlphabet/config.py
+++ b/TwoDAlphabet/config.py
@@ -418,7 +418,7 @@ class OrganizedHists():
                 h.SetTitle(row.out_histname)
                 if row.color not in mpl_to_root_colors.keys():
                     available_colors = '", "'.join(mpl_to_root_colors.keys())
-                    raise ValueError(f'Color "{color}" not defined. Please add the ROOT TColor code to the "mpl_to_root_colors" dictionary defined in TwoDAlphabet.plotstyle. Available default colors are: "{available_colors}"')
+                    raise ValueError(f'Color "{row.color}" not defined. Please add the ROOT TColor code to the "mpl_to_root_colors" dictionary defined in TwoDAlphabet.plotstyle. Available default colors are: "{available_colors}"')
                 else:
                     h.SetFillColor(mpl_to_root_colors[row.color])
 

--- a/TwoDAlphabet/ext/CMS_lumi.py
+++ b/TwoDAlphabet/ext/CMS_lumi.py
@@ -13,15 +13,16 @@ writeExtraText = True
 extraText   = "Preliminary"
 extraTextFont = 52 
 
-lumiTextSize     = 0.6
+lumiTextSize     = 0.35
 lumiTextOffset   = 0.2
 
-cmsTextSize      = 0.75
+cmsTextSize      = 0.4
 cmsTextOffset    = 0.15
 
-relPosX    = 0.045
-relPosY    = 0.035
-relExtraDY = 1.2
+relPosX    = 0.07
+relPosY    = -0.05
+relExtraDX = 2.8
+relExtraDY = 0.3
 
 extraOverCmsTextSize  = 0.76
 
@@ -160,8 +161,8 @@ def CMS_lumi(pad,  iPeriod=4,  iPosX=11, sim=False ):
                 latex.SetTextFont(extraTextFont)
                 latex.SetTextAlign(align_)
                 latex.SetTextSize(extraTextSize*t)
-                if not sim: latex.DrawLatex(posX_, posY_- relExtraDY*cmsTextSize*t, extraText)
-                else: latex.DrawLatex(posX_, posY_- relExtraDY*cmsTextSize*t, extraText + ' simulation')
+                if not sim: latex.DrawLatex(posX_+ relExtraDX*cmsTextSize*t, posY_-relExtraDY*cmsTextSize*t, extraText)
+                else: latex.DrawLatex(posX_+relExtraDX*cmsTextSize*t, posY_-relExtraDY*cmsTextSize*t, extraText + ' simulation')
     elif( writeExtraText ):
         if( iPosX==0):
             posX_ =   l +  relPosX*(1-l-r)

--- a/TwoDAlphabet/helpers.py
+++ b/TwoDAlphabet/helpers.py
@@ -325,7 +325,7 @@ def _combineTool_impacts_fix(fileNameExpected):
     potential_files_to_rename = glob.glob(seed_version)
 
     # Only run if there are seeded files to rename
-    if potential_files_to_rename > 0:
+    if len(potential_files_to_rename) > 0:
         all_seeds = list(set([f.split('.')[-2] for f in potential_files_to_rename]))
         if len(all_seeds) > 1:
             raise RuntimeError('More than one seed found when trying to move files for combineTool (%s). Clean up the area and try again.'%all_seeds)

--- a/TwoDAlphabet/helpers.py
+++ b/TwoDAlphabet/helpers.py
@@ -336,7 +336,7 @@ def _combineTool_impacts_fix(fileNameExpected):
 
 # ----------------- Inline condor submission --------------------
 class CondorRunner():
-    def __init__(self, name, primaryCmds, toPkg, runIn, toGrab, remakeEnv=False, eosRootfileTarball=None):
+    def __init__(self, name, primaryCmds, toPkg, runIn, toGrab, remakeEnv=False, eosRootfileTarball=None, lorienTag=False):
         '''Should be run in a CMSSW/src directory and not in a nested folder. All paths
         (besides the EOS rootfile tarball path) are treated relative to this folder.
 
@@ -355,24 +355,39 @@ class CondorRunner():
         self.primary_cmds = primaryCmds
         self.rootfile_tarball_path = eosRootfileTarball
         self.cmssw = os.environ['CMSSW_BASE'].split('/')[-1]
+        self.lorienTag = lorienTag
         if not os.path.exists('notneeded/'): execute_cmd('mkdir notneeded')
-        
-        self.env_tarball_path = make_env_tarball(remakeEnv)
-        self.pkg_tarball_path = self._make_pkg_tarball(toPkg) if toPkg != None else ''
-        self.run_script_path = self._make_run_script()
+
+        if not self.lorienTag:
+            self.env_tarball_path = make_env_tarball(remakeEnv)
+            self.pkg_tarball_path = self._make_pkg_tarball(toPkg) if toPkg != None else ''
+            self.run_script_path = self._make_run_script()
+        else:
+            self.run_script_path = self._make_run_script_lorien()
         self.run_args_path = self.run_script_path.replace('.sh','_args.txt')
 
+
     def submit(self):
-        abs_path = os.getcwd()
-        abs_twoD_dir_base = abs_path[:abs_path.find(self.cmssw)]+self.cmssw+'/src/2DAlphabet/TwoDAlphabet/'
+        abs_twoD_dir_base = os.path.dirname(os.path.abspath(__file__))
         timestr = time.strftime("%Y%m%d-%H%M%S")
         out_jdl = 'temp_'+timestr+'_jdl'
 
-        execute_cmd("sed 's$TEMPSCRIPT${0}$g' {1}/condor/jdl_template > {2}".format(self.run_script_path, abs_twoD_dir_base, out_jdl))
-        execute_cmd("sed -i 's$TEMPTAR${0}$g' {1}".format(self.pkg_tarball_path, out_jdl))
-        execute_cmd("sed -i 's$TEMPARGS${0}$g' {1}".format(self.run_args_path, out_jdl))
-        execute_cmd("condor_submit "+out_jdl)
-        execute_cmd("mv {0} notneeded/".format(out_jdl))
+        if not self.lorienTag:
+            execute_cmd("sed 's$TEMPSCRIPT${0}$g' {1}/condor/jdl_template > {2}".format(self.run_script_path, abs_twoD_dir_base, out_jdl))
+            execute_cmd("sed -i 's$TEMPTAR${0}$g' {1}".format(self.pkg_tarball_path, out_jdl))
+            execute_cmd("sed -i 's$TEMPARGS${0}$g' {1}".format(self.run_args_path, out_jdl))
+            execute_cmd("condor_submit "+out_jdl)
+            execute_cmd("mv {0} notneeded/".format(out_jdl))
+        else:
+            execute_cmd("sed 's$TEMPSCRIPT${0}$g' {1}/condor/jdl_template_lorien > {2}".format(self.run_script_path, abs_twoD_dir_base, out_jdl))
+            execute_cmd("sed -i 's$TEMPARGS${0}$g' {1}".format(self.run_args_path, out_jdl))
+            execute_cmd("chmod +x {0}".format(self.run_script_path))
+            execute_cmd("condor_submit "+out_jdl)
+            execute_cmd("mv {0} notneeded/".format(out_jdl))
+            print("Waiting for all jobs to finish...")
+            for log in glob.glob('notneeded/output_*.log'):
+                execute_cmd('condor_wait {0}'.format(log))
+            print("All jobs finished.")
 
     def _make_pkg_tarball(self,to_pkg):
         start_dir = os.getcwd()
@@ -423,6 +438,29 @@ class CondorRunner():
 
         return os.path.abspath(shell_name)
 
+    def _make_run_script_lorien(self):
+        blocks = []
+
+        blocks.append("#!/bin/bash")
+        blocks.append("echo RUNNING IN DIR: $(pwd)")
+        blocks.append("source /cvmfs/cms.cern.ch/cmsset_default.sh")
+        blocks.append('cd {0}'.format(os.environ['CMSSW_BASE']))
+        blocks.append('eval `scramv1 runtime -sh`')
+        blocks.append('cd -')
+        blocks.append('echo $*')
+        blocks.append('$*')
+
+        shell_name = 'run_'+self.name+'.sh'
+        with open(shell_name,'w') as run_script:
+            for block in blocks:
+                run_script.write(block+'\n')
+
+        with open(shell_name.replace('.sh','_args.txt'),'w') as run_args:
+            for c in self.primary_cmds:
+                run_args.write(c+'\n')
+
+        return os.path.abspath(shell_name)
+    
 def make_env_tarball(makeEnv=True):
     dir_base = os.environ['CMSSW_BASE']
     cmssw = dir_base.split('/')[-1]

--- a/TwoDAlphabet/helpers.py
+++ b/TwoDAlphabet/helpers.py
@@ -1,6 +1,22 @@
 import subprocess, json, ROOT, os, copy, time, glob
+import numpy as np
 from collections import defaultdict
 from contextlib import contextmanager
+
+# Function stolen from https://root-forum.cern.ch/t/trying-to-convert-rdf-generated-histogram-into-numpy-array/53428/3
+def hist2array(hist):
+    '''Create a numpy array from a ROOT histogram without external tools like root_numpy.
+
+    Args:
+        hist (TH1): Input ROOT histogram
+
+    Returns:
+        arr (np.ndarray): Array representing the ROOT histogram
+    '''
+    hist.BufferEmpty()
+    root_arr = hist.GetArray()
+    arr = np.ndarray((hist.GetNbinsX(),), dtype=np.float64, buffer=root_arr, order='C')
+    return arr
 
 # Function stolen from https://stackoverflow.com/questions/9590382/forcing-python-json-module-to-work-with-ascii
 def open_json(f):

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -367,7 +367,7 @@ class Plotter(object):
                 else:
                     these_axes = these_axes.loc[these_axes.logy.eq(True)]
 
-                if (len(these_axes) > 9) and (len(regionsToGroup) == 0):
+                if (len(these_axes) > 12) and (len(regionsToGroup) == 0):
                     raise RuntimeError('histlist of size %s not currently supported. Instead, call plot_projections() with regionsToGroup list describing the regions you want to group together.'%len(these_axes))
                 elif (len(these_axes) > 9) and (len(regionsToGroup) > 0):
                     validRegions = these_axes['region'].to_list()
@@ -656,6 +656,8 @@ def make_can(outname, padnames, padx=0, pady=0):
             padx = 3; pady = 2
         elif len(padnames) <= 9:
             padx = 3; pady = 3
+        elif len(padnames) <= 12:
+            padx = 6; pady = 2
         else:
             raise RuntimeError('histlist of size %s not currently supported'%len(padnames))
             #raise RuntimeError('histlist of size %s not currently supported: %s'%(len(padnames),[p.GetName() for p in padnames]))

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -898,17 +898,22 @@ def plot_correlation_matrix(varsToIgnore, threshold=0, corrText=False):
 
     fit_result_file.Close()
 
-def plot_gof(tag, subtag, seed=123456, condor=False):
+def plot_gof(tag, subtag, seed=123456, condor=False, lorien=False):
     with cd(tag+'/'+subtag):
         if condor:
-            tmpdir = 'notneeded/tmp/'
-            execute_cmd('mkdir '+tmpdir) 
-            execute_cmd('cat %s_%s_gof_toys_output_*.tgz | tar zxvf - -i --strip-components 2 -C %s'%(tag,subtag,tmpdir))
-            toy_limit_tree = ROOT.TChain('limit')
-            if len(glob.glob(tmpdir+'higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root')) == 0:
-                raise Exception('No files found')
-            toy_limit_tree.Add(tmpdir+'higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root') 
-            
+            if not lorien:
+                tmpdir = 'notneeded/tmp/'
+                execute_cmd('mkdir '+tmpdir) 
+                execute_cmd('cat %s_%s_gof_toys_output_*.tgz | tar zxvf - -i --strip-components 2 -C %s'%(tag,subtag,tmpdir))
+                toy_limit_tree = ROOT.TChain('limit')
+                if len(glob.glob(tmpdir+'higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root')) == 0:
+                    raise Exception('No files found')
+                toy_limit_tree.Add(tmpdir+'higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root') 
+            else:
+                toy_limit_tree = ROOT.TChain('limit')
+                if len(glob.glob('higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root')) == 0:
+                    raise Exception('No files found')
+                toy_limit_tree.Add('higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root')             
         else:
             toyOutput = ROOT.TFile.Open('higgsCombine_gof_toys.GoodnessOfFit.mH120.{seed}.root'.format(seed=seed))
             toy_limit_tree = toyOutput.Get('limit')
@@ -975,7 +980,7 @@ def plot_gof(tag, subtag, seed=123456, condor=False):
         cout.Print('gof_plot.pdf','pdf')
         cout.Print('gof_plot.png','png')
 
-    if condor:
+        if condor and not lorien:
             execute_cmd('rm -r '+tmpdir)
 
 def plot_signalInjection(tag, subtag, injectedAmount, seed=123456, stats=True, condor=False):
@@ -1021,7 +1026,7 @@ def plot_signalInjection(tag, subtag, injectedAmount, seed=123456, stats=True, c
         hsignstrength.Draw('pe')
         result_can.Print('signalInjection_r%s.png'%(str(injectedAmount).replace('.','p')),'png')
 
-    if condor:
+        if condor:
             execute_cmd('rm -r '+tmpdir)
 
 

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -43,6 +43,7 @@ class Plotter(object):
         self.dir = 'plots_fit_{f}'.format(f=self.fittag)
         self.slices = {'x': {}, 'y': {}}
         self.root_out = None
+        self.df_path = None
 
         if not loadExisting:
             self._make()
@@ -51,15 +52,20 @@ class Plotter(object):
 
     def __del__(self):
         '''On deletion, save DataFrame to csv and close ROOT file.'''
-        self.df.to_csv('%s/df.csv'%self.dir)
-        self.root_out.Close()
+        if self.df_path is not None:
+            self.df.to_csv(self.df_path)
+        if self.root_out is not None and hasattr(self.root_out, 'Close'):
+            self.root_out.Close()
 
     def _load(self):
         '''Open pickled DataFrame and output ROOT file
         and reference with `self.df` and `self.root_out` attributes.'''
         root_out_name = '%s/all_plots.root'%self.dir
         self.root_out = ROOT.TFile.Open(root_out_name)
-        self.df = pandas.read_csv('%s/df.csv'%self.dir)
+        
+        df_csv_path = os.path.join(self.dir, 'df.csv')
+        self.df = pandas.read_csv(df_csv_path)
+        self.df_path = df_csv_path
 
     def _format_1Dhist(self, hslice, title, xtitle, ytitle, color, proc_type):
         '''Perform some basic formatting of a 1D histogram so that the ROOT.TH1

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -636,19 +636,7 @@ def make_ax_1D(outname, binning, blinding, data, bkgs=[], signals=[], title='', 
             for i, title in enumerate(subtitle.split(';')):
                 ax.text(0.3, 0.95-(0.06*(i+1)), r'%s'%title, ha='center', va='top', fontsize='small', transform=ax.transAxes)
 
-    # Calculate pull (taking into consideration blinding)
-    if blinding == 1:
-        # 1: Blinding requested, we are plotting y-projection, and we are plotting SIG slice (Nan all pulls)
-        pulls = np.empty_like(data_arr,dtype=float); blind_arr.fill(np.nan)
-    else:
-        dataMinusBkg = data_arr - totalBkg_arr
-        data_error = np.where(dataMinusBkg<0, upper_errors - data_arr, data_arr - lower_errors)
-        sigmas = np.sqrt(data_error**2 + totalBkg_err**2) 
-        sigmas[sigmas==0.0] = 1e-5 # avoid division by zero 
-        pulls =  dataMinusBkg/sigmas
-    
-    # Plot pull on lower axis
-    rax.bar(bin_centers,pulls, width=widths, color='gray')
+    # Set up ratio plot axis
     rax.set_ylim(-3,3)
     rax.set_ylabel(r'$\frac{Data-Bkg}{\sigma}$')
     axisTitle = binning.xtitle if projn == 'x' else binning.ytitle
@@ -656,6 +644,14 @@ def make_ax_1D(outname, binning, blinding, data, bkgs=[], signals=[], title='', 
     rax.set_xlabel(r'${}$ [{}]'.format(axisTitle, units))
     rax.autoscale(axis='x', tight=True)
     rax.margins(x=0)
+    # Only plot the pulls if we are not entirely blinded (y-proj, SIG window)
+    if (blinding != 1):
+        dataMinusBkg = data_arr - totalBkg_arr
+        data_error = np.where(dataMinusBkg<0, upper_errors - data_arr, data_arr - lower_errors)
+        sigmas = np.sqrt(data_error**2 + totalBkg_err**2) 
+        sigmas[sigmas==0.0] = 1e-5 # avoid division by zero 
+        pulls =  dataMinusBkg/sigmas
+        rax.bar(bin_centers,pulls, width=widths, color='gray')
 
     if savePDF:
         plt.savefig(f'{outname}.pdf')

--- a/TwoDAlphabet/plot.py
+++ b/TwoDAlphabet/plot.py
@@ -922,6 +922,10 @@ def plot_gof(tag, subtag, seed=123456, condor=False, lorien=False):
         # Get observation
         ROOT.gROOT.SetBatch(True)
         ROOT.gStyle.SetOptStat(False)
+        ROOT.gStyle.SetOptFit(True)
+        ROOT.gStyle.SetFuncColor(2)
+        ROOT.gStyle.SetPadTickX(1)  # to get the tick marks on the opposite side of the frame
+        ROOT.gStyle.SetPadTickY(1)  # to get the tick marks on the opposite side of the frame
         gof_data_file = ROOT.TFile.Open('higgsCombine_gof_data.GoodnessOfFit.mH120.root')
         gof_limit_tree = gof_data_file.Get('limit')
         gof_limit_tree.GetEntry(0)

--- a/TwoDAlphabet/plotstyle.py
+++ b/TwoDAlphabet/plotstyle.py
@@ -1,0 +1,56 @@
+'''Container for matplotlib + mplhep format styles'''
+# Options for the figure object (analagous to TCanvas)
+fig_style = {
+    'figsize': (10, 10),
+    'dpi': 100
+}
+ratio_fig_style = {
+    'figsize': (10, 10),
+    'gridspec_kw': {'height_ratios': (3, 1)},
+    'dpi': 100
+}
+
+# Options for plotting
+stack_style = {
+    'edgecolor': (0, 0, 0, 0.5),
+}
+hatch_style = {
+    'facecolor': 'none',
+    'edgecolor': (0, 0, 0, 0.5),
+    'linewidth': 0,
+    'hatch': '///',
+}
+errorbar_style = {
+    'linestyle': 'none',
+    'marker': '.',      # display a dot for the datapoint
+    'elinewidth': 2,    # width of the errorbar line
+    'markersize': 10,   # size of the error marker
+    'capsize': 0,       # size of the caps on the errorbar (0: no cap fr)
+    'color': 'k',       # black 
+}
+shaded_style = {
+    'facecolor': (0,0,0,0.3),
+    'linewidth': 0
+}
+
+# Conversion from matplotlib color naming to ROOT TColor naming
+mpl_to_root_colors = {
+    'white': 0,
+    'black': 1,
+    'gray': 920, 
+    'red': 632, 
+    'green': 416, 
+    'blue': 600,
+    'yellow': 400,
+    'magenta': 616,
+    'cyan': 432,
+    'orange': 800, 
+    'spring': 820,
+    'teal': 840, 
+    'azure': 860,
+    'violet': 880,
+    'pink': 900
+}
+# And a helper function to return the matplotlib color name from ROOT TColor
+def root_to_matplotlib_color(TColor):
+    return list(mpl_to_root_colors.keys())[list(mpl_to_root_colors.values()).index(TColor)]

--- a/TwoDAlphabet/plotstyle.py
+++ b/TwoDAlphabet/plotstyle.py
@@ -24,7 +24,7 @@ errorbar_style = {
     'linestyle': 'none',
     'marker': '.',      # display a dot for the datapoint
     'elinewidth': 2,    # width of the errorbar line
-    'markersize': 10,   # size of the error marker
+    'markersize': 20,   # size of the error marker
     'capsize': 0,       # size of the caps on the errorbar (0: no cap fr)
     'color': 'k',       # black 
 }

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -44,6 +44,9 @@ class TwoDAlphabet:
 
         if not loadPrevious:
             self._setupProjDir()
+            #DEBUG
+            print(self.df.iloc[0].source_filename)
+            print(self.df.iloc[0].source_histname)
             template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
             template = template_file.Get(self.df.iloc[0].source_histname)
             template.SetDirectory(0)
@@ -148,7 +151,7 @@ class TwoDAlphabet:
             plot.make_systematic_plots(self)
 
 # --------------AlphaObj INTERFACE ------ #
-    def AddAlphaObj(self, process, region, obj, ptype='BKG', color=ROOT.kYellow, title=None):
+    def AddAlphaObj(self, process, region, obj, ptype='BKG', color='yellow', title=None):
         '''Start
 
         Args:

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -987,6 +987,8 @@ def make_postfit_workspace(d=''):
     w = w_f.Get('w')
     fr_f = ROOT.TFile.Open(d+'fitDiagnosticsTest.root')
     fr = fr_f.Get('fit_b')
+    if (fr == None):
+        raise ValueError(f'Fit result "fit_b" does not exist in fit result file {fr_f}')
     myargs = ROOT.RooArgSet(fr.floatParsFinal())
     w.saveSnapshot('initialFit',myargs,True)
     fout = ROOT.TFile('initialFitWorkspace.root', "recreate")

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -473,7 +473,7 @@ class TwoDAlphabet:
         return masked_regions
 
     def GoodnessOfFit(self, subtag, ntoys, card_or_w='card.txt', freezeSignal=False, seed=123456,
-                            verbosity=0, extra='', condor=False, eosRootfiles=None, njobs=0, makeEnv=False):
+                            verbosity=0, extra='', condor=False, eosRootfiles=None, njobs=0, makeEnv=False, lorienTag=False):
         # NOTE: There's no way to blind data here - need to evaluate it to get the p-value
         # param_str = '' if setParams == {} else '--setParameters '+','.join(['%s=%s'%(p,v) for p,v in setParams.items()])
 
@@ -530,7 +530,8 @@ class TwoDAlphabet:
                     runIn=run_dir,
                     toGrab=run_dir+'/higgsCombine_gof_toys.GoodnessOfFit.mH120.*.root',
                     eosRootfileTarball=eosRootfiles,
-                    remakeEnv=makeEnv
+                    remakeEnv=makeEnv,
+                    lorienTag=lorienTag
                 )
                 condor.submit()
             
@@ -608,7 +609,7 @@ class TwoDAlphabet:
                         toPkg=self.tag+'/',
                         toGrab=run_dir+'/higgsCombineTest.AsymptoticLimits.mH120.root',
                         eosRootfileTarball=eosRootfiles,
-                remakeEnv=makeEnv
+                        remakeEnv=makeEnv
                     )
                     condor.submit()
                 

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -590,7 +590,7 @@ class TwoDAlphabet:
                 condor.submit()
 
     def Limit(self, subtag, card_or_w='card.txt', blindData=True, verbosity=0,
-                    setParams={}, condor=False, eosRootfiles=None, makeEnv=False):
+                    setParams={}, condor=False, eosRootfiles=None, makeEnv=False, extra=''):
         if subtag == '': 
             raise RuntimeError('The subtag for limits must be non-empty so that the limit will be run in a nested directory.')
 
@@ -598,7 +598,7 @@ class TwoDAlphabet:
         _runDirSetup(run_dir)
 
         with cd(run_dir):
-            limit_cmd = _runLimit(blindData, verbosity, setParams, card_or_w, condor) # runs on this line if location == 'local'
+            limit_cmd = _runLimit(blindData, verbosity, setParams, card_or_w, condor, extra) # runs on this line if location == 'local'
             
             if condor:
                 if not makeEnv:
@@ -952,18 +952,19 @@ def _runMLfit(cardOrW, blinding, verbosity, rMin, rMax, setParams, usePreviousFi
 
     execute_cmd(fit_cmd, out='FitDiagnostics.log')
 
-def _runLimit(blindData, verbosity, setParams, card_or_w='card.txt', condor=False):
+def _runLimit(blindData, verbosity, setParams, card_or_w='card.txt', condor=False, extra=''):
     # card_or_w could be `morphedWorkspace.root --snapshotName morphedModel`
     param_options = ''
     if len(setParams) > 0:
         param_options = '--setParameters '+','.join('%s=%s'%(k,v) for k,v in setParams.items())
 
-    limit_cmd = 'combine -M AsymptoticLimits -d {card_or_w} --saveWorkspace --cminDefaultMinimizerStrategy 0 {param_opt} {blind_opt} -v {verb}' 
+    limit_cmd = 'combine -M AsymptoticLimits -d {card_or_w} --saveWorkspace --cminDefaultMinimizerStrategy 0 {param_opt} {blind_opt} -v {verb} {extra}' 
     limit_cmd = limit_cmd.format(
         card_or_w=card_or_w,
         blind_opt='--run=blind' if blindData else '',
         param_opt=param_options,
-        verb=verbosity
+        verb=verbosity,
+        extra=extra
     )
 
     # Run combine if not on condor

--- a/TwoDAlphabet/twoDalphabet.py
+++ b/TwoDAlphabet/twoDalphabet.py
@@ -44,9 +44,6 @@ class TwoDAlphabet:
 
         if not loadPrevious:
             self._setupProjDir()
-            #DEBUG
-            print(self.df.iloc[0].source_filename)
-            print(self.df.iloc[0].source_histname)
             template_file = ROOT.TFile.Open(self.df.iloc[0].source_filename)
             template = template_file.Get(self.df.iloc[0].source_histname)
             template.SetDirectory(0)


### PR DESCRIPTION
Added matplotlib+mplhep style plotting to the primary 2DAlphabet plotting methods, some QoL updates as well. Features + additions:
* `TwoDAlphabet/config.py`:
    * Added verbosity flag to optionally print regions, processes, and systematics dataframes as .txt files 
* `TwoDAlphabet/helpers.py`:
    * Added simplified version of `hist2array` method from deprecated `root_numpy` module. Handles under/overflow bins and can optionally return a numpy array containing the sum of weights squared representing the uncertainty for MC samples
* `TwoDAlphabet.plotstyle`:
    * File containing default plotting styles for use with matplotlib+mplhep. Mostly contains dictionaries that can be unpacked as `**kwargs` to matplotlib plotting methods. 
    * Added `mpl_to_root_colors` dict which maps matplotlib string colors to the corresponding ROOT::TColor integer color code. Users can add their own color codes to this dict if desired, and will be warned if they try to use a string for which a corresponding TColor is not defined. 
    * `root_to_matplotlib_color()` method which returns a matplotlib color name from a ROOT TColor integer as long as it exists in the above dict
* `TwoDAlphabet/plot.py`:
    * Major overhaul to `plot_projections()` method. Additional arguments:
        * `lumiText`: latex-formatted raw string containing the luminosity information + sqrt(s). This text goes in the top right above the figure box. Defaults to run2 conditions
        * `extraText`: string to go after the CMS experiment text in the upper left above the figure box. Defaults to `Preliminary`.
        * `subtitles`: Dict of raw strings corresponding to each region specified in the JSON to be placed under the opposite axis slice text  in the top left corner of the main figure box. If you want multiple titles separated by a new line, use a `;` character. 
            * Example: `subtitles= {"SR_fail": r"$ParticleNet_{TvsQCD}$ Pass;$ParticleNetMD_{Xbb}$ Fail", "SR_pass": r"$ParticleNet_{TvsQCD}$ Pass;$ParticleNetMD_{Xbb}$ Pass;ASIMOV DATA"}` will produce `SR_fail` and `SR_pass` region plots containing the subtitle strings
![image](https://github.com/user-attachments/assets/c16c7c6b-bec6-423c-bbdf-b2b06ebba229)
![image](https://github.com/user-attachments/assets/8cfafb6c-6b05-4f57-bbc1-9d3b975d2ad5)
, respectively
        * `units`: string for the units to be used in x-axis title and opposite axis slice title
        * `regionsToGroup`: This is a niche option, probably will not be used very often. The idea is that, by default, 2DAlphabet can only handle (3 regions) x (3 opposite axis slices) = 9 total figures when making the postfit projections. If someone were to fit two regions simultaneously, e.g. `SR_fail -> SR_pass` + `CR_fail -> CR_pass`, 2DAlphabet would try to plot 12 total figures. The `regionsToGroup` option solves this by having the user specify individual regions to plot and an option three-region group to plot (the max supported by 2DAlphabet). 
            * Example: Say a CR and SR are simultaneously fit and the user wants to see the CRFail+CRPass, SRFail+SRPass, and then SRFail+SRPass+CRPass. They would pass `regionsToGroup=[['CR'], ['SR'], ['SR_fail','SR_pass','CR_pass']]`.
    * Renamed `make_pad_1D()` $\to$ `make_ax_1D()`, since we are dealing with `matplotlib.pyplot.axis` objects now. Changed the entire function to handle plotting a single figure (a projection along a given axis in a slice of the other axis) using matplotlib+mplhep
    * Updated `make_systematic_plots()` method:
        * now uses matplotlib+mplhep to draw the process and $\pm1\sigma$ shape templates
        * In the loop over systematics, while looping over processes check that the systematic actually exists for the given process
    * Updated `nuis_pulls()` method to add the following args that are passed to `diffNuisances.py`:
        * `vtol=0.3, stol=0.1, vtol2=2.0, stol2=0.5` default parameters governing the value and sigma tolerances and warnings
        * `regex='^(?!.*(_bin_|_par))'`: regex string to select/omit parameters. In this case, it will omit all parameters with `_bin_` and `_par` in the name, which correspond to the unconstrained data-driven estimate bins and transfer function parameters, respectively. This acts to format the plot properly by removing them from consideration - without this they would appear as empty spaces in the plot and the other nuisances would be squished together. User should not need to change these values, but now can if desired. 
* `TwoDAlphabet/twoDalphabet.py`:
    * Overhauled the `StdPlots()` method, which just acts to call `Plotter.nuis_pulls()`, `Plotter.save_post_fit_parametric_vals()`, `Plotter.plot_correlation_matrix( )`, `Plotter.gen_post_fit_shapes()`, and `Plotter.gen_projections()`. This user-facing function now includes all the new options detailed previously

 